### PR TITLE
Send []string as a post request parameter in /bitget-golang-sdk-api.

### DIFF
--- a/bitget-golang-sdk-api/internal/utils.go
+++ b/bitget-golang-sdk-api/internal/utils.go
@@ -93,6 +93,10 @@ func NewParams() map[string]string {
 	return make(map[string]string)
 }
 
+func NewParamsArrStr() map[string][]string {
+	return make(map[string][]string)
+}
+
 func ToJson(v interface{}) (string, error) {
 	result, err := json.Marshal(v)
 	if err != nil {

--- a/bitget-golang-sdk-api/pkg/client/BitgetApiclient.go
+++ b/bitget-golang-sdk-api/pkg/client/BitgetApiclient.go
@@ -23,6 +23,15 @@ func (p *BitgetApiClient) Post(url string, params map[string]string) (string, er
 	return resp, err
 }
 
+func (p *BitgetApiClient) PostArr(url string, params map[string][]string) (string, error) {
+	postBody, jsonErr := internal.ToJson(params)
+	if jsonErr != nil {
+		return "", jsonErr
+	}
+	resp, err := p.BitgetRestClient.DoPost(url, postBody)
+	return resp, err
+}
+
 func (p *BitgetApiClient) Get(url string, params map[string]string) (string, error) {
 	resp, err := p.BitgetRestClient.DoGet(url, params)
 	return resp, err


### PR DESCRIPTION
Added PostArr function to send a request with parameters in an array of strings.